### PR TITLE
remove aes-gcm algos from Ciphers, because of http://www.openssh.com/txt/gcmrekey.adv

### DIFF
--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -58,7 +58,7 @@ LogLevel VERBOSE
 # eg ruby Net::SSH::Transport::CipherFactory requires cbc-versions of the given openssh ciphers to work
 # -- see: (http://net-ssh.github.com/net-ssh/classes/Net/SSH/Transport/CipherFactory.html)
 # 
-Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes128-ctr,aes256-ctr,aes192-ctr<% if @node['ssh']['cbc_required'] == true %>,aes128-cbc,aes256-cbc,aes192-cbc<% end %>
+Ciphers aes128-ctr,aes256-ctr,aes192-ctr<% if @node['ssh']['cbc_required'] == true %>,aes128-cbc,aes256-cbc,aes192-cbc<% end %>
 
 # **Hash algorithms** -- Make sure not to use SHA1 for hashing, unless it is really necessary.
 # Weak HMAC is sometimes required if older package versions are used 

--- a/test/integration/default/serverspec/ssh_spec.rb
+++ b/test/integration/default/serverspec/ssh_spec.rb
@@ -71,7 +71,7 @@ describe 'check sshd_config' do
     end
 
     describe file('/etc/ssh/sshd_config') do
-        its(:content) { should match /^Ciphers (aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes128-ctr,aes256-ctr,aes192-ctr)|(aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes128-ctr,aes256-ctr,aes192-ctr,aes128-cbc,aes256-cbc,aes192-cbc)$/}
+        its(:content) { should match /^Ciphers (aes128-ctr,aes256-ctr,aes192-ctr)|(aes128-ctr,aes256-ctr,aes192-ctr,aes128-cbc,aes256-cbc,aes192-cbc)$/}
     end
 
     describe file('/etc/ssh/sshd_config') do


### PR DESCRIPTION
Also i adjusted the kitchen test and tested it

Signed-off-by: Patrick Meier patrick.meier111@googlemail.com
