### PR TITLE
Debian6fix

### DIFF
--- a/libraries/get_ssh_kex.rb
+++ b/libraries/get_ssh_kex.rb
@@ -46,7 +46,6 @@ class Chef
         elsif node['platform_family'] == 'rhel'
           kex = {}
           kex.default = nil
-          kex['weak'] = nil
         end
 
         # deactivate kex on debian 6
@@ -54,7 +53,6 @@ class Chef
           Chef::Log.info('Detected Debian 6 or earlier, disable KEX')
           kex = {}
           kex.default = nil
-          kex['weak'] = nil
         end
 
         Chef::Log.info("Choose kex: #{kex[weak_kex]}")


### PR DESCRIPTION
- disable KEX on debian 6
- remove redundant specification of weak kex if kex is disabled
