### PR TITLE
Add slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.3
+- 1.9.3
+- 2.0.0
+- 2.1.3
 language: ruby
-bundler_args: --without development integration openstack
+bundler_args: "--without development integration openstack"
 notifications:
   slack:
     secure: bOxdT8KjXuWpBaNvMsf1zGcBRS5Ua3ESYcBWUEXXKE+f+AatmATCdynHq1QJBzE6NtWcGvxlacF4oA3FMmMhJZW9PF3igmYK2TC/aF8TXQ+nE8uzibkj+BphI6/so6TnXCPxoCp6TQ8gZm9cWyj1M4gnFJiZx9eYMVKCIOSRU/0=


### PR DESCRIPTION
Playing around with slack integration for travis:
This adds notifications using an encrypted token set up using the travis cli (http://docs.travis-ci.com/user/encryption-keys/)

The travis cli indents the yaml file a little different, so I figured it would do no harm to update the file to the canonical form.
