### PR TITLE
add coverage dir to gitignore, add chefignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ README.html
 shared_test_repo/
 test/integration
 .kitchen
+coverage
 
 Gemfile.lock
 Berksfile.lock

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,19 @@
+# os generated
+.DS_Store
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# artefacts
+*/coverage
+
+# tests
+*/*file
+*/*file.lock
+*/spec
+*/test
+*/bundle
+*/vendor
+
+# self
+*/chefignore


### PR DESCRIPTION
coveralls creates a `coverage` directory that we don't want to have in git.
Also this pr adds a chefignore file to keep our releases void of test files and artifacts.
