### PR TITLE
remove options that only apply to SSH protocol version 1

### DIFF
--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -81,10 +81,6 @@ MACs <%= @mac %>
 KexAlgorithms <%= @kex %>
 <% end %>
 
-# Lifetime and size of ephemeral version 1 server key
-KeyRegenerationInterval 1h
-ServerKeyBits 2048
-
 # Authentication
 # --------------
 
@@ -98,13 +94,11 @@ MaxSessions 10
 MaxStartups 10:30:100
 
 # Enable public key authentication
-RSAAuthentication yes
 PubkeyAuthentication yes
 
 # Never use host-based authentication. It can be exploited.
 IgnoreRhosts yes
 IgnoreUserKnownHosts yes
-RhostsRSAAuthentication no
 HostbasedAuthentication no
 
 # Enable PAM to enforce system wide rules


### PR DESCRIPTION
Remove options that only apply to SSH v1.

In reference to feedback here: https://github.com/TelekomLabs/chef-ssh-hardening/issues/57

Signed-off-by: Dominik Richter dominik.richter@gmail.com
