### PR TITLE
update to rubocop 0.27, exclude Berksfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 ---
 AllCops:
   Exclude:
+  - Berksfile
   - vendor/**/*
   - test/**/*
   - metadata.rb
@@ -22,3 +23,5 @@ Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
   Max: 10
+Metrics/AbcSize:
+  Max: 29

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'chefspec',   '~> 4.1.1'
   gem 'foodcritic', '~> 3.0'
   gem 'thor-foodcritic'
-  gem 'rubocop',    '~> 0.26.1'
+  gem 'rubocop',    '~> 0.27.0'
   gem 'coveralls',  require: false
 end
 


### PR DESCRIPTION
rubocop 0.27.0 is out and introduces the new metric AbcSize: https://github.com/bbatsov/rubocop/issues/1077
Some files would need quite a refactoring to please the default setting of 10, so I bumped the allowed metric to 29 in rubocop.yml.
