### PR TITLE
Use new InSpec integration tests

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -1,0 +1,53 @@
+---
+driver:
+  name: vagrant
+provisioner:
+  name: chef_solo
+  test_repo_uri: https://github.com/TelekomLabs/tests-ssh-hardening.git
+platforms:
+- name: ubuntu-12.04
+  driver_config:
+    box: ubuntu/precise64
+    box_url: https://atlas.hashicorp.com/ubuntu/boxes/precise64/versions/20150730.1.0/providers/virtualbox.box
+- name: ubuntu-14.04
+  driver_config:
+    box: ubuntu/trusty64
+    box_url: https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/20150609.0.10/providers/virtualbox.box
+- name: centos-6.4
+  driver_config:
+    box: opscode-centos-6.4
+    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
+- name: centos-6.5
+  driver_config:
+    box: opscode-centos-6.5
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+- name: centos-7.1
+  driver_config:
+    box: opscode-centos-7.1
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.1_chef-provisionerless.box
+- name: oracle-6.4
+  driver_config:
+    box: oracle-6.4
+    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel64-64.box
+- name: oracle-6.5
+  driver_config:
+    box: oracle-6.5
+    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box
+- name: debian-6
+  driver_config:
+    box: ffuenf/debian-6.0.10-amd64
+    box_url: https://atlas.hashicorp.com/ffuenf/boxes/debian-6.0.10-amd64/versions/1.0.11/providers/virtualbox.box
+- name: debian-7
+  driver_config:
+    box: debian/wheezy64
+    box_url: https://atlas.hashicorp.com/debian/boxes/wheezy64/versions/7.8.5/providers/virtualbox.box
+- name: debian-8
+  driver_config:
+    box: debian/jessie64
+    box_url: https://atlas.hashicorp.com/debian/boxes/jessie64/versions/8.1.0/providers/virtualbox.box
+verifier:
+  name: inspec
+suites:
+- name: default
+  run_list:
+  - - role[ssh]

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -45,9 +45,15 @@ platforms:
   driver_config:
     box: debian/jessie64
     box_url: https://atlas.hashicorp.com/debian/boxes/jessie64/versions/8.1.0/providers/virtualbox.box
+
 verifier:
   name: inspec
+  sudo: true
+
 suites:
 - name: default
   run_list:
-  - - role[ssh]
+  - recipe[ssh-hardening]
+  verifier:
+    inspec_tests:
+      - https://github.com/dev-sec/tests-ssh-hardening

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -1,9 +1,10 @@
 ---
 driver:
   name: vagrant
+
 provisioner:
   name: chef_solo
-  test_repo_uri: https://github.com/TelekomLabs/tests-ssh-hardening.git
+
 platforms:
 - name: ubuntu-12.04
   driver_config:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,27 +1,71 @@
 ---
 driver:
   name: dokken
-#  chef_version: 12.5.1
-#  privileged: true # because Docker and SystemD/Upstart
+  chef_version: 12.5.1
+  privileged: true # because Docker and SystemD/Upstart
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
-#  name: chef_solo
-  #test_repo_uri: https://github.com/TelekomLabs/tests-ssh-hardening.git
 
 verifier:
   name: inspec
   sudo: true
 
 platforms:
-- name: ubuntu
+- name: ubuntu-12.04
+  driver:
+    image: ubuntu:12.04
+- name: ubuntu-14.04
   driver:
     image: ubuntu:14.04
+- name: ubuntu-15.10
+  driver:
+    image: ubuntu:15.10
+    pid_one_command: /bin/systemd
+- name: ubuntu-16.04
+  driver:
+    image: ubuntu:16.04
+    pid_one_command: /bin/systemd
+- name: centos-6.6
+  driver:
+    image: centos:6.6
+- name: centos-6.7
+  driver:
+    image: centos:6.7
+    intermediate_instructions:
+      - RUN yum install -y initscripts
+- name: centos-7
+  driver:
+    image: centos:7
+    pid_one_command: /usr/lib/systemd/systemd
+- name: oracle-6.6
+  driver:
+    image: oraclelinux:6.6
+- name: oracle-6.7
+  driver:
+    image: oraclelinux:6.7
+- name: oracle-7.1
+  driver:
+    image: oraclelinux:7.1
+    pid_one_command: /usr/lib/systemd/systemd
+- name: debian-7
+  driver:
+    image: debian:7
+    intermediate_instructions:
+    - RUN /usr/bin/apt-get update
+    - RUN /usr/bin/apt-get install -y procps
+- name: debian-8
+  driver:
+    image: debian:8
+    intermediate_instructions:
+    - RUN /usr/bin/apt-get update
+    - RUN /usr/bin/apt-get install -y procps
+    pid_one_command: /bin/systemd
 
 suites:
 - name: default
   run_list:
-  - - role[ssh]
+  - recipe[ssh-hardening::default]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,52 +1,26 @@
 ---
 driver:
-  name: vagrant
+  name: dokken
+#  chef_version: 12.5.1
+#  privileged: true # because Docker and SystemD/Upstart
+
+transport:
+  name: dokken
+
 provisioner:
-  name: chef_solo
-  test_repo_uri: https://github.com/TelekomLabs/tests-ssh-hardening.git
-platforms:
-- name: ubuntu-12.04
-  driver_config:
-    box: ubuntu/precise64
-    box_url: https://atlas.hashicorp.com/ubuntu/boxes/precise64/versions/20150730.1.0/providers/virtualbox.box
-- name: ubuntu-14.04
-  driver_config:
-    box: ubuntu/trusty64
-    box_url: https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/20150609.0.10/providers/virtualbox.box
-- name: centos-6.4
-  driver_config:
-    box: opscode-centos-6.4
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
-- name: centos-6.5
-  driver_config:
-    box: opscode-centos-6.5
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
-- name: centos-7.1
-  driver_config:
-    box: opscode-centos-7.1
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.1_chef-provisionerless.box
-- name: oracle-6.4
-  driver_config:
-    box: oracle-6.4
-    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel64-64.box
-- name: oracle-6.5
-  driver_config:
-    box: oracle-6.5
-    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box
-- name: debian-6
-  driver_config:
-    box: ffuenf/debian-6.0.10-amd64
-    box_url: https://atlas.hashicorp.com/ffuenf/boxes/debian-6.0.10-amd64/versions/1.0.11/providers/virtualbox.box
-- name: debian-7
-  driver_config:
-    box: debian/wheezy64
-    box_url: https://atlas.hashicorp.com/debian/boxes/wheezy64/versions/7.8.5/providers/virtualbox.box
-- name: debian-8
-  driver_config:
-    box: debian/jessie64
-    box_url: https://atlas.hashicorp.com/debian/boxes/jessie64/versions/8.1.0/providers/virtualbox.box
+  name: dokken
+#  name: chef_solo
+  #test_repo_uri: https://github.com/TelekomLabs/tests-ssh-hardening.git
+
 verifier:
   name: inspec
+  sudo: true
+
+platforms:
+- name: ubuntu
+  driver:
+    image: ubuntu:14.04
+
 suites:
 - name: default
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,6 +28,8 @@ platforms:
 - name: ubuntu-16.04
   driver:
     image: ubuntu:16.04
+    intermediate_instructions:
+    - RUN /usr/bin/apt-get update
     pid_one_command: /bin/systemd
 - name: centos-6.6
   driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,7 +9,6 @@ transport:
 
 provisioner:
   name: dokken
-  test_repo_uri: https://github.com/dev-sec/tests-ssh-hardening.git
 
 verifier:
   name: inspec
@@ -72,3 +71,6 @@ suites:
 - name: default
   run_list:
   - recipe[ssh-hardening::default]
+  verifier:
+    inspec_tests:
+      - https://github.com/dev-sec/tests-ssh-hardening

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -70,6 +70,8 @@ platforms:
 suites:
 - name: default
   run_list:
+  - recipe[apt]
+  - recipe[yum]
   - recipe[ssh-hardening::default]
   verifier:
     inspec_tests:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,7 @@ transport:
 
 provisioner:
   name: dokken
+  test_repo_uri: https://github.com/dev-sec/tests-ssh-hardening.git
 
 verifier:
   name: inspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   - test/**/*
   - metadata.rb
   - Berksfile
+  - Guardfile
 Documentation:
   Enabled: false
 AlignParameters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,37 +8,24 @@ services:
 - docker
 
 before_install:
-- gem install bundler
 - gem --version
+- bundle version
 
 matrix:
   include:
-  - rvm: 1.9.3
-    gemfile: Gemfile
-    bundler_args: "--without integration guard tools"
+  # verify lint and unit
   - rvm: 1.9.3
     gemfile: gemfile.chef-11
     bundler_args: "--without integration guard tools"
-  - rvm: 2.2.4
+  - rvm: 2.3.1
     gemfile: Gemfile
     bundler_args: "--without integration guard tools"
-  - rvm: 2.2.4
-    gemfile: gemfile.chef-11
-    bundler_args: "--without integration guard tools"
-  - rvm: ruby-head
-    gemfile: Gemfile
-    bundler_args: "--without integration guard tools"
-  - rvm: ruby-head
-    gemfile: gemfile.chef-11
-    bundler_args: "--without integration guard tools"
-  - rvm: 2.2.4
+  # integration tests
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake test:integration OS='centos oracle'
     gemfile: Gemfile
-  - rvm: 2.2.4
+  - rvm: 2.3.1
     bundler_args: "--without guard tools"
     script: bundle exec rake test:integration OS='ubuntu debian'
     gemfile: Gemfile
-  allow_failures:
-  - rvm: ruby-head
-  - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ before_install:
 matrix:
   include:
   # verify lint and unit
-  - rvm: 1.9.3
-    gemfile: gemfile.chef-11
-    bundler_args: "--without integration guard tools"
   - rvm: 2.3.1
     gemfile: Gemfile
     bundler_args: "--without integration guard tools"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,22 @@ rvm:
 gemfile:
 - Gemfile
 - gemfile.chef-11
+sudo: required
 language: ruby
-bundler_args: "--without development integration openstack"
+cache: bundler
+dist: trusty
+services:
+- docker
+bundler_args: "--without integration guard tools"
+before_install:
+- gem install bundler
+- gem --version
+matrix:
+  include:
+  - rvm: 1.9.3
+  - rvm: 2.0
+  - rvm: 2.1
+  - rvm: ruby-head
+  - rvm: 2.2
+    bundler_args: "--without guard tools"
+    script: bundle exec rake test:integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,44 @@
 ---
-rvm:
-- 2.0.0
-- 2.1.3
-gemfile:
-- Gemfile
-- gemfile.chef-11
 sudo: required
 language: ruby
 cache: bundler
 dist: trusty
+
 services:
 - docker
-bundler_args: "--without integration guard tools"
+
 before_install:
 - gem install bundler
 - gem --version
+
 matrix:
   include:
   - rvm: 1.9.3
-  - rvm: 2.0
-  - rvm: 2.1
+    gemfile: Gemfile
+    bundler_args: "--without integration guard tools"
+  - rvm: 1.9.3
+    gemfile: gemfile.chef-11
+    bundler_args: "--without integration guard tools"
+  - rvm: 2.2.4
+    gemfile: Gemfile
+    bundler_args: "--without integration guard tools"
+  - rvm: 2.2.4
+    gemfile: gemfile.chef-11
+    bundler_args: "--without integration guard tools"
   - rvm: ruby-head
-  - rvm: 2.2
+    gemfile: Gemfile
+    bundler_args: "--without integration guard tools"
+  - rvm: ruby-head
+    gemfile: gemfile.chef-11
+    bundler_args: "--without integration guard tools"
+  - rvm: 2.2.4
     bundler_args: "--without guard tools"
-    script: bundle exec rake test:integration
+    script: bundle exec rake test:integration OS='centos oracle'
+    gemfile: Gemfile
+  - rvm: 2.2.4
+    bundler_args: "--without guard tools"
+    script: bundle exec rake test:integration OS='ubuntu debian'
+    gemfile: Gemfile
+  allow_failures:
+  - rvm: ruby-head
+  - rvm: 1.9.3

--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,5 @@ source "https://supermarket.getchef.com"
 metadata
 
 cookbook "chef-solo-search", :git => "https://github.com/edelight/chef-solo-search"
+cookbook "apt"
+cookbook "yum"

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ end
 group :integration do
   gem 'test-kitchen', '~> 1.0'
   gem 'kitchen-vagrant'
-  gem 'kitchen-inspec', '~> 0.9'
+  gem 'kitchen-inspec', '~> 0'
   gem 'kitchen-sharedtests', '~> 0.2.0'
   gem 'concurrent-ruby', '~> 0.9'
   gem 'kitchen-dokken'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,12 @@ source 'https://rubygems.org'
 
 gem 'berkshelf',  '~> 4.0'
 gem 'chef',       '>= 12.0'
-gem 'inspec', '~> 0'
+
+# pin dependency for Ruby 1.9.3 since bundler is not
+# detecting that net-ssh 3 does not work with 1.9.3
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
+  gem 'net-ssh', '~> 2.9'
+end
 
 group :test do
   gem 'rake'
@@ -13,7 +18,6 @@ group :test do
   gem 'thor-foodcritic'
   gem 'rubocop',    '~> 0.31.0'
   gem 'coveralls',  require: false
-  gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
   gem 'simplecov', '~> 0.10'
 end
@@ -29,7 +33,7 @@ end
 group :integration do
   gem 'test-kitchen', '~> 1.0'
   gem 'kitchen-vagrant'
-  gem 'kitchen-inspec', '~> 0'
+  gem 'kitchen-inspec'
   gem 'kitchen-sharedtests', '~> 0.2.0'
   gem 'concurrent-ruby', '~> 0.9'
   gem 'kitchen-dokken'

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :integration do
   gem 'kitchen-inspec', '~> 0.9'
   gem 'kitchen-sharedtests', '~> 0.2.0'
   gem 'concurrent-ruby', '~> 0.9'
+  gem 'kitchen-dokken'
 end
 
 group :openstack do

--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,14 @@ source 'https://rubygems.org'
 
 gem 'berkshelf',  '~> 4.0'
 gem 'chef',       '>= 12.0'
-gem 'inspec', '~> 0.9'
+gem 'inspec', '~> 0'
 
 group :test do
   gem 'rake'
   gem 'chefspec',   '~> 4.2.0'
   gem 'foodcritic', '~> 4.0'
   gem 'thor-foodcritic'
-  gem 'rubocop',    '~> 0.28.0'
+  gem 'rubocop',    '~> 0.31.0'
   gem 'coveralls',  require: false
   gem 'bundler', '~> 1.5'
   gem 'minitest', '~> 5.5'
@@ -39,5 +39,5 @@ group :openstack do
 end
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1'
+  gem 'github_changelog_generator', '~> 1.12.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,6 @@ group :integration do
   gem 'kitchen-dokken'
 end
 
-group :openstack do
-  gem 'kitchen-openstack'
-end
-
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -9,16 +9,11 @@ require 'rubocop/rake_task'
 
 # Rubocop before rspec so we don't lint vendored cookbooks
 desc 'Run all tests except Kitchen (default task)'
-task integration: %w(rubocop foodcritic spec)
-task default: [:integration]
-
-# Lint the cookbook
-desc 'Run linters'
-task lint: [:rubocop, :foodcritic]
+task default: [:lint, :spec]
 
 # Lint the cookbook
 desc 'Run all linters: rubocop and foodcritic'
-task run_all_linters: [:rubocop, :foodcritic]
+task lint: [:rubocop, :foodcritic]
 
 # Run the whole shebang
 desc 'Run all tests'
@@ -51,17 +46,6 @@ task :rubocop do
   RuboCop::RakeTask.new
 end
 
-begin
-  require 'kitchen/rake_tasks'
-  Kitchen::RakeTasks.new
-
-  desc 'Alias for kitchen:all'
-  task acceptance: 'kitchen:all'
-
-rescue LoadError
-  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
-end
-
 # Automatically generate a changelog for this project. Only loaded if
 # the necessary gem is installed.
 begin
@@ -74,7 +58,7 @@ end
 namespace :test do
   task :integration do
     concurrency = ENV['CONCURRENCY'] || 1
-    path = File.join(File.dirname(__FILE__), 'test', 'integration')
-    sh('sh', '-c', "bundle exec kitchen test -c #{concurrency}")
+    os = ENV['OS'] || ''
+    sh('sh', '-c', "bundle exec kitchen test -c #{concurrency} #{os}")
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -70,3 +70,11 @@ begin
 rescue LoadError
   puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end
+
+namespace :test do
+  task :integration do
+    concurrency = ENV['CONCURRENCY'] || 1
+    path = File.join(File.dirname(__FILE__), 'test', 'integration')
+    sh('sh', '-c', "bundle exec kitchen test -c #{concurrency}")
+  end
+end

--- a/gemfile.chef-11
+++ b/gemfile.chef-11
@@ -5,6 +5,12 @@ source 'https://rubygems.org'
 gem 'berkshelf',  '~> 4.0'
 gem 'chef',       '~> 11.18'
 
+# pin dependency for Ruby 1.9.3 since bundler is not
+# detecting that net-ssh 3 does not work with 1.9.3
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
+  gem 'net-ssh', '~> 2.9'
+end
+
 group :test do
   gem 'rake'
   gem 'chefspec',   '~> 4.1.1'
@@ -25,6 +31,8 @@ end
 group :integration do
   gem 'test-kitchen', '~> 1.0'
   gem 'kitchen-vagrant'
+  gem 'kitchen-inspec'
+  gem 'kitchen-dokken'
   gem 'kitchen-sharedtests', '~> 0.2.0'
 end
 

--- a/gemfile.chef-11
+++ b/gemfile.chef-11
@@ -2,7 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'berkshelf',  '~> 4.0'
 gem 'chef',       '~> 11.18'
 
 # pin dependency for Ruby 1.9.3 since bundler is not
@@ -34,8 +33,4 @@ group :integration do
   gem 'kitchen-inspec'
   gem 'kitchen-dokken'
   gem 'kitchen-sharedtests', '~> 0.2.0'
-end
-
-group :openstack do
-  gem 'kitchen-openstack'
 end

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -366,12 +366,12 @@ describe 'ssh-hardening::server' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |_node, server|
         server.create_data_bag(
-        'users',
-        'user1' => { id: 'user1', ssh_rootkey: 'key-user1' },
-        'user2' => { id: 'user2', ssh_rootkey: 'key-user2' },
-        'user3' => { id: 'user3', ssh_rootkeys: %w(key1-user3 key2-user3) },
-        'user4' => { id: 'user4', ssh_rootkeys: %w(key1-user4) }
-      )
+          'users',
+          'user1' => { id: 'user1', ssh_rootkey: 'key-user1' },
+          'user2' => { id: 'user2', ssh_rootkey: 'key-user2' },
+          'user3' => { id: 'user3', ssh_rootkeys: %w(key1-user3 key2-user3) },
+          'user4' => { id: 'user4', ssh_rootkeys: %w(key1-user4) }
+        )
       end.converge(described_recipe)
     end
 


### PR DESCRIPTION
The bundle install command failed because of the github_changelog_generator 1.10.4. So updated it to github_changelog_generator 1.12.0 and also rubocop to 0.31.0.


Signed-off-by: Patrick Münch <patrick.muench1111@gmail.com>