### PR TITLE
Document MaxAuthTries and MaxSessions added in 66e7ebfd

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ This cookbook provides secure ssh-client and ssh-server configurations.
 * `['ssh']['use_pam']` - `false` to disable pam authentication
 * `['ssh']['print_motd']` - `false` to disable printing of the MOTD
 * `['ssh']['print_last_log']` - `false` to disable display of last login information
+* `['ssh']['max_auth_tries']` - controls `MaxAuthTries`; the number of authentication attempts per connection.
+* `['ssh']['max_sessions']` - controls `MaxSessions`; the number of sessions per connection.
 * `['ssh']['deny_users']` - `[]` to configure `DenyUsers`, if specified login is disallowed for user names that match one of the patterns.
 * `['ssh']['allow_users']` - `[]` to configure `AllowUsers`, if specified, login is allowed only for user names that match one of the patterns.
 * `['ssh']['deny_groups']` - `[]` to configure `DenyGroups`, if specified, login is disallowed for users whose primary group or supplementary group list matches one of the patterns.


### PR DESCRIPTION
A very simple documentation change.

I realised that the ability to control MaxAuthTries and MaxSessions was actually added almost a year ago, but isn't present in the released v1.10 - could you cut a release, please?