### PR TITLE
activate fedora integration tests in travis

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,10 +21,6 @@ platforms:
 - name: ubuntu-14.04
   driver:
     image: ubuntu:14.04
-- name: ubuntu-15.10
-  driver:
-    image: ubuntu:15.10
-    pid_one_command: /bin/systemd
 - name: ubuntu-16.04
   driver:
     image: ubuntu:16.04
@@ -66,6 +62,19 @@ platforms:
     - RUN /usr/bin/apt-get update
     - RUN /usr/bin/apt-get install -y procps
     pid_one_command: /bin/systemd
+- name: fedora-23
+  driver:
+    image: fedora:23
+    pid_one_command: /usr/lib/systemd/systemd
+    # Chef needs yum package for now: https://github.com/chef/chef/issues/3201
+    intermediate_instructions:
+    - RUN dnf install -y yum
+- name: fedora-24
+  driver:
+    image: fedora:24
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+    - RUN dnf install -y yum
 
 suites:
 - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,21 @@ matrix:
   # integration tests
   - rvm: 2.3.1
     bundler_args: "--without guard tools"
-    script: bundle exec rake test:integration OS='centos oracle'
-    gemfile: Gemfile
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='centos'
   - rvm: 2.3.1
     bundler_args: "--without guard tools"
-    script: bundle exec rake test:integration OS='ubuntu debian'
-    gemfile: Gemfile
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='oracle'
+  - rvm: 2.3.1
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='ubuntu'
+  - rvm: 2.3.1
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='debian'
+  - rvm: 2.3.1
+    bundler_args: "--without guard tools"
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='fedora'


### PR DESCRIPTION
* activates fedora 23 and 24
* removes ubuntu 15.10 from travis since 16.04 is included