### PR TITLE
Use bracket syntax in attributes/default.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 #
 
 # Define the client package name
-case platform
+case node['platform']
 when 'redhat', 'centos', 'fedora', 'amazon', 'oracle', 'scientific'
   default['sshclient']['package'] = 'openssh-clients'
 when 'debian', 'ubuntu'


### PR DESCRIPTION
>method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"])