### PR TITLE
Fix deprecation warnings

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -46,7 +46,7 @@ end
       message "ssh/client/#{setting} set from deprecated ssh/#{setting}"
       level :warn
     end
-    node.set['ssh']['client'][setting] = node['ssh'][setting]
+    node.default['ssh']['client'][setting] = node['ssh'][setting]
   else
     log "ignored-ssh/#{setting}_client" do
       message "Ignoring ssh/#{setting}:true for client"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -76,7 +76,7 @@ end
       message "ssh/server/#{setting} set from deprecated ssh/#{setting}"
       level :warn
     end
-    node.set['ssh']['server'][setting] = node['ssh'][setting]
+    node.default['ssh']['server'][setting] = node['ssh'][setting]
   else
     log "ignored-ssh/#{setting}_server" do
       message "Ignoring ssh/#{setting}:true for server"

--- a/spec/recipes/client_spec.rb
+++ b/spec/recipes/client_spec.rb
@@ -76,7 +76,7 @@ describe 'ssh-hardening::client' do
   context 'weak_hmac enabled only for the client' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['client']['weak_hmac'] = true
+        node.normal['ssh']['client']['weak_hmac'] = true
       end.converge(described_recipe)
     end
 
@@ -93,7 +93,7 @@ describe 'ssh-hardening::client' do
   context 'weak_hmac enabled only for the server' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['server']['weak_hmac'] = true
+        node.normal['ssh']['server']['weak_hmac'] = true
       end.converge(described_recipe)
     end
 
@@ -106,7 +106,7 @@ describe 'ssh-hardening::client' do
   context 'weak_kex enabled for the client only' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['client']['weak_kex'] = true
+        node.normal['ssh']['client']['weak_kex'] = true
       end.converge(described_recipe)
     end
 
@@ -127,7 +127,7 @@ describe 'ssh-hardening::client' do
   context 'weak_kexs enabled for the server only' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['server']['weak_kex'] = true
+        node.normal['ssh']['server']['weak_kex'] = true
       end.converge(described_recipe)
     end
 
@@ -144,7 +144,7 @@ describe 'ssh-hardening::client' do
   context 'cbc_required set for the client only' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['client']['cbc_required'] = true
+        node.normal['ssh']['client']['cbc_required'] = true
       end.converge(described_recipe)
     end
 
@@ -163,7 +163,7 @@ describe 'ssh-hardening::client' do
   context 'cbc_required set for the server only' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['server']['cbc_required'] = true
+        node.normal['ssh']['server']['cbc_required'] = true
       end.converge(described_recipe)
     end
 
@@ -177,7 +177,7 @@ describe 'ssh-hardening::client' do
     context 'legacy attribute ssl/weak_hmac set' do
       cached(:chef_run) do
         ChefSpec::ServerRunner.new do |node|
-          node.set['ssh']['weak_hmac'] = true
+          node.normal['ssh']['weak_hmac'] = true
         end.converge(described_recipe)
       end
 
@@ -210,7 +210,7 @@ describe 'ssh-hardening::client' do
     context 'legacy attribute weak_kex set' do
       cached(:chef_run) do
         ChefSpec::ServerRunner.new do |node|
-          node.set['ssh']['weak_kex'] = true
+          node.normal['ssh']['weak_kex'] = true
         end.converge(described_recipe)
       end
 
@@ -243,7 +243,7 @@ describe 'ssh-hardening::client' do
     context 'legacy attribute cbc_required set' do
       cached(:chef_run) do
         ChefSpec::ServerRunner.new do |node|
-          node.set['ssh']['cbc_required'] = true
+          node.normal['ssh']['cbc_required'] = true
         end.converge(described_recipe)
       end
 
@@ -289,9 +289,9 @@ describe 'ssh-hardening::client' do
         # don't use cache, log persists
         let(:chef_run) do
           ChefSpec::ServerRunner.new do |node|
-            node.set['ssh'][attr] = true
-            node.set['ssh']['client'][attr] = false
-            node.set['ssh']['server'][attr] = true
+            node.normal['ssh'][attr] = true
+            node.normal['ssh']['client'][attr] = false
+            node.normal['ssh']['server'][attr] = true
           end.converge(described_recipe)
         end
 
@@ -306,9 +306,9 @@ describe 'ssh-hardening::client' do
         # don't use cache, log persists
         let(:chef_run) do
           ChefSpec::ServerRunner.new do |node|
-            node.set['ssh'][attr] = true
-            node.set['ssh']['client'][attr] = true
-            node.set['ssh']['server'][attr] = false
+            node.normal['ssh'][attr] = true
+            node.normal['ssh']['client'][attr] = true
+            node.normal['ssh']['server'][attr] = false
           end.converge(described_recipe)
         end
 

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -79,7 +79,7 @@ describe 'ssh-hardening::server' do
   context 'with weak hmacs enabled for the server' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['server']['weak_hmac'] = true
+        node.normal['ssh']['server']['weak_hmac'] = true
       end.converge(described_recipe)
     end
 
@@ -96,7 +96,7 @@ describe 'ssh-hardening::server' do
   context 'with weak hmacs enabled for only the client' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node, server|
-        node.set['ssh']['server']['client']['weak_hmac'] = true
+        node.normal['ssh']['server']['client']['weak_hmac'] = true
         server.create_data_bag('users', 'someuser' => { id: 'someuser' })
       end.converge(described_recipe)
     end
@@ -110,7 +110,7 @@ describe 'ssh-hardening::server' do
   context 'weak_kex enabled for only the server' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['server']['weak_kex'] = true
+        node.normal['ssh']['server']['weak_kex'] = true
       end.converge(described_recipe)
     end
 
@@ -131,7 +131,7 @@ describe 'ssh-hardening::server' do
   context 'weak_kex enabled for only the client' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node, server|
-        node.set['ssh']['client']['weak_kex'] = true
+        node.normal['ssh']['client']['weak_kex'] = true
         server.create_data_bag('users', 'someuser' => { id: 'someuser' })
       end.converge(described_recipe)
     end
@@ -149,7 +149,7 @@ describe 'ssh-hardening::server' do
   context 'cbc_required for the server only' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['server']['cbc_required'] = true
+        node.normal['ssh']['server']['cbc_required'] = true
       end.converge(described_recipe)
     end
 
@@ -168,7 +168,7 @@ describe 'ssh-hardening::server' do
   context 'cbc_required for the client only' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node, server|
-        node.set['ssh']['client']['cbc_required'] = true
+        node.normal['ssh']['client']['cbc_required'] = true
         server.create_data_bag('users', 'someuser' => { id: 'someuser' })
       end.converge(described_recipe)
     end
@@ -184,7 +184,7 @@ describe 'ssh-hardening::server' do
       cached(:chef_run) do
         ChefSpec::ServerRunner.new do |node, server|
           server.create_data_bag('users', 'someuser' => { id: 'someuser' })
-          node.set['ssh']['weak_hmac'] = true
+          node.normal['ssh']['weak_hmac'] = true
         end.converge(described_recipe)
       end
 
@@ -217,7 +217,7 @@ describe 'ssh-hardening::server' do
     context 'legacy attribute weak_kex set' do
       cached(:chef_run) do
         ChefSpec::ServerRunner.new do |node, server|
-          node.set['ssh']['weak_kex'] = true
+          node.normal['ssh']['weak_kex'] = true
           server.create_data_bag('users', 'someuser' => { id: 'someuser' })
         end.converge(described_recipe)
       end
@@ -251,7 +251,7 @@ describe 'ssh-hardening::server' do
     context 'legacy attribute cbc_required set' do
       cached(:chef_run) do
         ChefSpec::ServerRunner.new do |node, server|
-          node.set['ssh']['cbc_required'] = true
+          node.normal['ssh']['cbc_required'] = true
           server.create_data_bag('users', 'someuser' => { id: 'someuser' })
         end.converge(described_recipe)
       end
@@ -297,9 +297,9 @@ describe 'ssh-hardening::server' do
           # don't use cache, log persists
           let(:chef_run) do
             ChefSpec::ServerRunner.new do |node, server|
-              node.set['ssh'][attr] = true
-              node.set['ssh']['client'][attr] = true
-              node.set['ssh']['server'][attr] = false
+              node.normal['ssh'][attr] = true
+              node.normal['ssh']['client'][attr] = true
+              node.normal['ssh']['server'][attr] = false
               server.create_data_bag('users', 'someuser' => { id: 'someuser' })
             end.converge(described_recipe)
           end
@@ -315,9 +315,9 @@ describe 'ssh-hardening::server' do
           # don't use cache, log persists
           let(:chef_run) do
             ChefSpec::ServerRunner.new do |node, server|
-              node.set['ssh'][attr] = true
-              node.set['ssh']['client'][attr] = false
-              node.set['ssh']['server'][attr] = true
+              node.normal['ssh'][attr] = true
+              node.normal['ssh']['client'][attr] = false
+              node.normal['ssh']['server'][attr] = true
               server.create_data_bag('users', 'someuser' => { id: 'someuser' })
             end.converge(described_recipe)
           end
@@ -352,7 +352,7 @@ describe 'ssh-hardening::server' do
   context 'with attribute allow_root_with_key' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['allow_root_with_key'] = true
+        node.normal['ssh']['allow_root_with_key'] = true
       end.converge(described_recipe)
     end
 
@@ -449,7 +449,7 @@ describe 'ssh-hardening::server' do
   context 'with attribute deny_users' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['deny_users'] = %w(someuser)
+        node.normal['ssh']['deny_users'] = %w(someuser)
       end.converge(described_recipe)
     end
 
@@ -462,7 +462,7 @@ describe 'ssh-hardening::server' do
   context 'with attribute deny_users mutiple' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['deny_users'] = %w(someuser otheruser)
+        node.normal['ssh']['deny_users'] = %w(someuser otheruser)
       end.converge(described_recipe)
     end
 
@@ -482,7 +482,7 @@ describe 'ssh-hardening::server' do
   context 'with attribute use_dns set to false' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['use_dns'] = false
+        node.normal['ssh']['use_dns'] = false
       end.converge(described_recipe)
     end
 
@@ -495,7 +495,7 @@ describe 'ssh-hardening::server' do
   context 'with attribute use_dns set to true' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['use_dns'] = true
+        node.normal['ssh']['use_dns'] = true
       end.converge(described_recipe)
     end
 
@@ -515,7 +515,7 @@ describe 'ssh-hardening::server' do
   context 'with attribute ["sftp"]["enable"] set to true' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['sftp']['enable'] = true
+        node.normal['ssh']['sftp']['enable'] = true
       end.converge(described_recipe)
     end
 
@@ -528,8 +528,8 @@ describe 'ssh-hardening::server' do
   context 'with attribute ["sftp"]["enable"] set to true and ["sftp"]["group"] set to "testgroup"' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['sftp']['enable'] = true
-        node.set['ssh']['sftp']['group'] = 'testgroup'
+        node.normal['ssh']['sftp']['enable'] = true
+        node.normal['ssh']['sftp']['group'] = 'testgroup'
       end.converge(described_recipe)
     end
 
@@ -542,8 +542,8 @@ describe 'ssh-hardening::server' do
   context 'with attribute ["sftp"]["enable"] set to true and ["sftp"]["chroot"] set to "/export/home/%u"' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['ssh']['sftp']['enable'] = true
-        node.set['ssh']['sftp']['chroot'] = 'test_home_dir'
+        node.normal['ssh']['sftp']['enable'] = true
+        node.normal['ssh']['sftp']['chroot'] = 'test_home_dir'
       end.converge(described_recipe)
     end
 


### PR DESCRIPTION
`node.set` causes deprecation warnings in tests (found while writing a cookbook to setup a bastion SSH server).

I changed the specs to `node.normal` because that’s what the ChefSpec readme now [recommends](https://github.com/sethvargo/chefspec#setting-node-attributes) (a change made by the maintainer after getting reports of the same deprecation warnings) and because `node.default` broke tests.

The recipes I changed to `node.default`, which is a little different underneath because default attributes don’t persist and ones set by `node.set`/`node.normal` do. I did this for several reasons:
* The Chef attributes doc [recommends](https://docs.chef.io/attributes.html#attribute-types) using `node.default` as often as possible.
* The Chef Style Guide [recommends](https://docs.chef.io/ruby.html#node-set) avoiding `node.set`/`node.normal`.
* The loop where they’re used executes on every Chef client run so it feels better to start with defaults and clean up only if needed, rather than preserving values from previous runs.

All ChefSpecs and kitchens pass.

There is already coverage of the legacy attr support for both recipes tests what gets rendered into the configs. I could add tests that the new attrs are updated when the old attrs are used, but that doesn't feel very valuable. I can add them if you think that’s better, though, no problem.

Let me know if you see any problems or you’d like anything done differently and I’ll rebase it in. Thanks!

Platform used to run ChefSpec:
```
> chef --version

Chef Development Kit Version: 0.17.17

chef-client version: 12.13.37

delivery version: master (f68e5c5804cd7d8a76c69b926fbb261e1070751b)

berks version: 4.3.5

kitchen version: 1.11.1

> chef exec rspec --version

3.5.2

```