### PR TITLE
Parameterise Banner and DebianBanner as attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,9 @@ default['ssh']['deny_groups']             = []      # sshd
 default['ssh']['allow_groups']            = []      # sshd
 default['ssh']['print_motd']              = false   # sshd
 default['ssh']['print_last_log']          = false   # sshd
+default['ssh']['banner']                  = false   # sshd
+default['ssh']['os_banner']               = false   # sshd (Debian OS family)
+
 # set this to nil to let us use the default OpenSSH in case it's not set by the user
 default['ssh']['use_dns']                 = nil     # sshd
 # set this to nil to let us detect the attribute based on the node platform

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -177,7 +177,12 @@ X11UseLocalhost yes
 
 PrintMotd <%= ((@node['ssh']['print_motd']) ? 'yes' : 'no' ) %>
 PrintLastLog <%= ((@node['ssh']['print_last_log']) ? 'yes' : 'no' ) %>
-#Banner /etc/ssh/banner.txt
+Banner <%= @node['ssh']['banner'] ? '/etc/ssh/banner.txt' : 'none' %>
+
+<% if @node['platform_family'] == 'debian' %>
+DebianBanner <%= @node['ssh']['os_banner'] ? 'yes' : 'no' %>
+<% end %>
+
 <% if @node['ssh']['use_dns'].nil? %>
 # Since OpenSSH 6.8, this value defaults to 'no'
 #UseDNS no


### PR DESCRIPTION
This commit parameterises `Banner` and `DebianBanner` in the sshd config
with the attributes `['ssh']['banner']` and `['ssh']['os_banner']` respectively,
though the latter is only supported on Debian family distributions.

Debian based distributions will have `DebianBanner no` set by default
from now on.