### PR TITLE
Avoid duplicate resource names because of warnings

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -23,11 +23,11 @@ package 'openssh-client' do
   package_name node['sshclient']['package']
 end
 
-directory '/etc/ssh' do
+directory 'openssh-client ssh directory /etc/ssh' do
+  path '/etc/ssh'
   mode '0755'
   owner 'root'
   group 'root'
-  action :create
 end
 
 # warn about cipher depreciations and support legacy attributes

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -53,11 +53,11 @@ service 'sshd' do
   action [:enable, :start]
 end
 
-directory '/etc/ssh' do
+directory 'openssh-server ssh directory /etc/ssh' do
+  path '/etc/ssh'
   mode '0755'
   owner 'root'
   group 'root'
-  action :create
 end
 
 # warn about cipher depreciations and support legacy attributes


### PR DESCRIPTION
```
Cloning resource attributes for directory[/etc/ssh] from prior resource (CHEF-3694)
Previous directory[/etc/ssh]: /tmp/kitchen/cache/cookbooks/ssh-hardening/recipes/server.rb:56:in `from_file'
Current  directory[/etc/ssh]: /tmp/kitchen/cache/cookbooks/ssh-hardening/recipes/client.rb:26:in `from_file' at 1 location:
```