### PR TITLE
Update kitchen vagrant configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ bin/*
 # Test Kitchen
 .kitchen/
 .kitchen.local.yml
+
+# RVM
+/.ruby-gemset
+/.ruby-version

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -4,52 +4,23 @@ driver:
 
 provisioner:
   name: chef_solo
+  require_chef_omnibus: 12.5.1
 
 platforms:
 - name: ubuntu-12.04
-  driver_config:
-    box: ubuntu/precise64
-    box_url: https://atlas.hashicorp.com/ubuntu/boxes/precise64/versions/20150730.1.0/providers/virtualbox.box
 - name: ubuntu-14.04
-  driver_config:
-    box: ubuntu/trusty64
-    box_url: https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/20150609.0.10/providers/virtualbox.box
-- name: centos-6.4
-  driver_config:
-    box: opscode-centos-6.4
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
-- name: centos-6.5
-  driver_config:
-    box: opscode-centos-6.5
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
-- name: centos-7.1
-  driver_config:
-    box: opscode-centos-7.1
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.1_chef-provisionerless.box
-- name: oracle-6.4
-  driver_config:
-    box: oracle-6.4
-    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel64-64.box
-- name: oracle-6.5
-  driver_config:
-    box: oracle-6.5
-    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box
-- name: debian-6
-  driver_config:
-    box: ffuenf/debian-6.0.10-amd64
-    box_url: https://atlas.hashicorp.com/ffuenf/boxes/debian-6.0.10-amd64/versions/1.0.11/providers/virtualbox.box
-- name: debian-7
-  driver_config:
-    box: debian/wheezy64
-    box_url: https://atlas.hashicorp.com/debian/boxes/wheezy64/versions/7.8.5/providers/virtualbox.box
-- name: debian-8
-  driver_config:
-    box: debian/jessie64
-    box_url: https://atlas.hashicorp.com/debian/boxes/jessie64/versions/8.1.0/providers/virtualbox.box
+- name: ubuntu-16.04
+- name: centos-6.8
+- name: centos-7.2
+- name: debian-7.11
+- name: debian-8.6
+- name: fedora-23
+- name: fedora-24
+- name: opensuse-leap-42.1
+- name: opensuse-13.2
 
 verifier:
   name: inspec
-  sudo: true
 
 suites:
 - name: default

--- a/README.md
+++ b/README.md
@@ -12,15 +12,18 @@ This cookbook provides secure ssh-client and ssh-server configurations.
 
 ## Requirements
 
-* Opscode chef
+* Chef >= 12.5.1
 
 ### Platform
 
 - Debian 7, 8
 - Ubuntu 12.04, 14.04, 16.04
-- RHEL 6.6, 6.7, 7
-- CentOS 6.6, 6.7, 7
-- OracleLinux 6.6, 6.7, 7
+- RHEL 6, 7
+- CentOS 6, 7
+- Oracle Linux 6, 7
+- Fedora 23, 24
+- OpenSuse Leap 42.1
+- OpenSuse 13.2
 
 ## Attributes
 


### PR DESCRIPTION
- Switching all boxes to the bento (its maintained)
- Removing oracle boxes as there is no reliable source with maintenance for them
- Limiting centos only to the last major versions (the minors are not really important)

Testing on fedora bento boxes is currently broken: https://github.com/chef/bento/pull/709