### PR TITLE
Configurable SSH Banner File

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This cookbook provides secure ssh-client and ssh-server configurations.
 * `['ssh']['use_pam']` - `false` to disable pam authentication
 * `['ssh']['print_motd']` - `false` to disable printing of the MOTD
 * `['ssh']['print_last_log']` - `false` to disable display of last login information
+* `['ssh']['banner']` - `nil` to disable banner or provide a path like '/etc/issue.net'
 * `['ssh']['max_auth_tries']` - controls `MaxAuthTries`; the number of authentication attempts per connection.
 * `['ssh']['max_sessions']` - controls `MaxSessions`; the number of sessions per connection.
 * `['ssh']['deny_users']` - `[]` to configure `DenyUsers`, if specified login is disallowed for user names that match one of the patterns.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,7 +71,8 @@ default['ssh']['deny_groups']             = []      # sshd
 default['ssh']['allow_groups']            = []      # sshd
 default['ssh']['print_motd']              = false   # sshd
 default['ssh']['print_last_log']          = false   # sshd
-default['ssh']['banner']                  = false   # sshd
+# set this to nil to disable banner or provide a path like '/etc/issue.net'
+default['ssh']['banner']                  = nil     # sshd
 default['ssh']['os_banner']               = false   # sshd (Debian OS family)
 
 # set this to nil to let us use the default OpenSSH in case it's not set by the user

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -177,7 +177,7 @@ X11UseLocalhost yes
 
 PrintMotd <%= ((@node['ssh']['print_motd']) ? 'yes' : 'no' ) %>
 PrintLastLog <%= ((@node['ssh']['print_last_log']) ? 'yes' : 'no' ) %>
-Banner <%= @node['ssh']['banner'] ? '/etc/ssh/banner.txt' : 'none' %>
+Banner <%= @node['ssh']['banner'] ? @node['ssh']['banner'] : 'none' %>
 
 <% if @node['platform_family'] == 'debian' %>
 DebianBanner <%= @node['ssh']['os_banner'] ? 'yes' : 'no' %>


### PR DESCRIPTION
Path to the Banner File in template 'opensshd.conf.erb' is hard coded to '/etc/ssh/banner.txt'
Not all flavours use this. (for example, CentOS defaults to etc/issue.net)
I have made this configurable by adding an attribute.