### PR TITLE
Get rid of chefspec/fauxhai warnings in the unit tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,5 +24,11 @@ require 'coveralls'
 Coveralls.wear!
 at_exit { ChefSpec::Coverage.report! }
 
+RSpec.configure do |config|
+  # OS and version for mocking of ohai data, needed by chefspec
+  config.platform = 'ubuntu'
+  config.version = '16.04'
+end
+
 require_relative '../libraries/devsec_ssh'
 require_relative 'shared_examples_crypto'


### PR DESCRIPTION
```
WARNING: you must specify a platform and platform_version to your ChefSpec Runner and/or Fauxhai constructor, in the future omitting these will become a hard error
```