### PR TITLE
Removal of apt/yum cookbooks from tests

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -27,6 +27,7 @@ verifier:
 suites:
 - name: default
   run_list:
+  - recipe[test]
   - recipe[ssh-hardening]
   verifier:
     inspec_tests:
@@ -44,6 +45,7 @@ suites:
     vagrantfiles:
       - test/fixtures/vagrantfiles/enforce_selinux.rb
   run_list:
+  - recipe[test]
   - recipe[ssh-hardening]
   attributes:
     ssh-hardening:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -86,9 +86,8 @@ platforms:
 suites:
 - name: default
   run_list:
-  - recipe[apt]
-  - recipe[yum]
-  - recipe[ssh-hardening::default]
+  - recipe[test]
+  - recipe[ssh-hardening]
   verifier:
     inspec_tests:
       - https://github.com/dev-sec/tests-ssh-hardening

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,6 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'apt'
-cookbook 'yum'
+group :test do
+  cookbook 'test', path: 'test/fixtures/cookbooks/test'
+end

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,0 +1,9 @@
+name             'test'
+maintainer       'Dominik Richter'
+maintainer_email 'dominik.richter@googlemail.com'
+license          'Apache 2.0'
+description      'This cookbook is used for testing purposes'
+long_description 'This cookbook is used for testing purposes'
+version          '0.0.1'
+
+depends 'compat_resource', '>= 12.16.3'

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+#
+# Cookbook Name:: test
+# Recipe:: default.rb
+#
+# Copyright 2017, Artem Sidorenko
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if node['platform_family'] == 'debian'
+  apt_update 'update-apt-cache' do
+    action :update
+  end
+end


### PR DESCRIPTION
They produce broken builds and we do not need them anymore:
https://travis-ci.org/dev-sec/chef-ssh-hardening/jobs/201236096

In the same time we need to run apt-get update at the start of chef-run
as ubuntu does not have any apt repo information. This is the reason
for introduction of test cookbook.