### PR TITLE
CI: update to ruby 2.4.1 and gem update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
   - vendor/**/*
   - test/**/*
+  TargetRubyVersion: 2.3 # we need this because of chef 12 support
 Metrics/AbcSize:
   Max: 29
 Metrics/CyclomaticComplexity:
@@ -16,17 +17,22 @@ Metrics/PerceivedComplexity:
   Max: 10
 Style/Documentation:
   Enabled: false
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
   Enabled: true
 Style/Encoding:
   EnforcedStyle: always
   Enabled: true
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Exclude:
     - attributes/default.rb
 Style/RegexpLiteral:
   AllowInnerSlashes: true
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Exclude:
     - attributes/default.rb
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache: bundler
 services:
 - docker
 
-rvm: 2.3.3
+rvm: 2.4.1
 
 before_install:
   - gem update --system # see https://github.com/bundler/bundler/issues/5357

--- a/Gemfile
+++ b/Gemfile
@@ -2,21 +2,21 @@
 
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 5.3'
-gem 'chef', '~> 12.5'
+gem 'berkshelf', '~> 6.1'
+gem 'chef', '~> 12.5' # chefspec builds get stucked with 13.1
 
 group :test do
-  gem 'chefspec', '~> 5.3.0'
+  gem 'chefspec', '~> 7.1.0'
   gem 'coveralls', require: false
-  gem 'foodcritic', '~> 6.0'
+  gem 'foodcritic', '~> 11.1'
   gem 'rake'
-  gem 'rubocop', '~> 0.46.0'
+  gem 'rubocop', '~> 0.49.0'
   gem 'simplecov', '~> 0.10'
 end
 
 group :development do
   gem 'guard'
-  gem 'guard-foodcritic', '~>2.1'
+  gem 'guard-foodcritic', '~> 3.0'
   gem 'guard-rspec'
   gem 'guard-rubocop'
 end
@@ -29,5 +29,5 @@ group :integration do
 end
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
-#!/usr/bin/env rake
 # encoding: utf-8
+
+# rubocop:disable Style/SymbolArray
 
 require 'foodcritic'
 require 'rspec/core/rake_task'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: ssh-hardening
 # Attributes:: default

--- a/libraries/devsec_ssh.rb
+++ b/libraries/devsec_ssh.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: ssh-hardening
 # Library:: devsec_ssh
@@ -41,28 +42,28 @@ module DevSec
     # Fallback ssh version for autodetection
     FALLBACK_SSH_VERSION ||= 5.9
     # Support types of ssh
-    SSH_TYPES ||= [:client, :server].freeze
+    SSH_TYPES ||= %i[client server].freeze
     # Crypto configuration for different ssh parameters
     CRYPTO ||= {
       kexs: {
         5.3 => [],
-        5.9 => %w(diffie-hellman-group-exchange-sha256),
-        6.6 => %w(curve25519-sha256@libssh.org diffie-hellman-group-exchange-sha256),
-        :weak => %w(diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1)
+        5.9 => %w[diffie-hellman-group-exchange-sha256],
+        6.6 => %w[curve25519-sha256@libssh.org diffie-hellman-group-exchange-sha256],
+        :weak => %w[diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1]
       },
       macs: {
-        5.3 => %w(hmac-ripemd160 hmac-sha1),
-        5.9 => %w(hmac-sha2-512 hmac-sha2-256 hmac-ripemd160),
-        6.6 => %w(hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com
+        5.3 => %w[hmac-ripemd160 hmac-sha1],
+        5.9 => %w[hmac-sha2-512 hmac-sha2-256 hmac-ripemd160],
+        6.6 => %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com
                   hmac-ripemd160-etm@openssh.com umac-128-etm@openssh.com
-                  hmac-sha2-512 hmac-sha2-256 hmac-ripemd160),
-        :weak => %w(hmac-sha1)
+                  hmac-sha2-512 hmac-sha2-256 hmac-ripemd160],
+        :weak => %w[hmac-sha1]
       },
       ciphers: {
-        5.3 => %w(aes256-ctr aes192-ctr aes128-ctr),
-        6.6 => %w(chacha20-poly1305@openssh.com aes256-gcm@openssh.com aes128-gcm@openssh.com
-                  aes256-ctr aes192-ctr aes128-ctr),
-        :weak => %w(aes256-cbc aes192-cbc aes128-cbc)
+        5.3 => %w[aes256-ctr aes192-ctr aes128-ctr],
+        6.6 => %w[chacha20-poly1305@openssh.com aes256-gcm@openssh.com aes128-gcm@openssh.com
+                  aes256-ctr aes192-ctr aes128-ctr],
+        :weak => %w[aes256-cbc aes192-cbc aes128-cbc]
       }
     }.freeze
     # Privilege separation values
@@ -73,9 +74,9 @@ module DevSec
     # Hostkey algorithms
     # In the current implementation they are server specific so we need own data hash for it
     HOSTKEY_ALGORITHMS ||= {
-      5.3 => %w(rsa),
-      6.0 => %w(rsa ecdsa),
-      6.6 => %w(rsa ecdsa ed25519)
+      5.3 => %w[rsa],
+      6.0 => %w[rsa ecdsa],
+      6.6 => %w[rsa ecdsa ed25519]
     }.freeze
 
     class << self

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,10 +19,12 @@
 name             'ssh-hardening'
 maintainer       'Dominik Richter'
 maintainer_email 'dominik.richter@googlemail.com'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'This cookbook installs and provides secure ssh and sshd configurations.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.1.0'
+
+chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '>= 6.0'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: ssh-hardening
 # Recipe:: client.rb

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: ssh-hardening
 # Recipe:: default.rb

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: ssh-hardening
 # Recipe:: server.rb
@@ -44,7 +45,7 @@ package 'openssh-server' do
 end
 
 # Handle addional SELinux policy on RHEL/Fedora for different UsePAM options
-if %w(fedora rhel).include?(node['platform_family'])
+if %w[fedora rhel].include?(node['platform_family'])
   policy_file = ::File.join(cache_dir, 'ssh_password.te')
   module_file = ::File.join(cache_dir, 'ssh_password.mod')
   package_file = ::File.join(cache_dir, 'ssh_password.pp')
@@ -139,19 +140,19 @@ service 'sshd' do
   end
   service_name node['ssh-hardening']['sshserver']['service_name']
   supports value_for_platform(
-    'centos' => { 'default' => [:restart, :reload, :status] },
-    'redhat' => { 'default' => [:restart, :reload, :status] },
-    'fedora' => { 'default' => [:restart, :reload, :status] },
-    'scientific' => { 'default' => [:restart, :reload, :status] },
+    'centos' => { 'default' => %i[restart reload status] },
+    'redhat' => { 'default' => %i[restart reload status] },
+    'fedora' => { 'default' => %i[restart reload status] },
+    'scientific' => { 'default' => %i[restart reload status] },
     'arch' => { 'default' => [:restart] },
-    'debian' => { 'default' => [:restart, :reload, :status] },
+    'debian' => { 'default' => %i[restart reload status] },
     'ubuntu' => {
-      '8.04' => [:restart, :reload],
-      'default' => [:restart, :reload, :status]
+      '8.04' => %i[restart reload],
+      'default' => %i[restart reload status]
     },
-    'default' => { 'default' => [:restart, :reload] }
+    'default' => { 'default' => %i[restart reload] }
   )
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 directory 'openssh-server ssh directory /etc/ssh' do

--- a/recipes/unlock.rb
+++ b/recipes/unlock.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: ssh-hardening
 # Recipe:: unlock

--- a/spec/libraries/devsec_ssh_spec.rb
+++ b/spec/libraries/devsec_ssh_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Copyright 2016, Artem Sidorenko
 #
@@ -267,7 +268,7 @@ describe DevSec::Ssh do
   # get_[client|server]_[kexs|macs|ciphers]
   # In order to cover all possible combinations, we need a complex nested loops:-\
   # We start with client|server combination
-  %w(client server).each do |type|
+  %w[client server].each do |type|
     # Go over different types of crypto parameters, e.g. kexs, macs, ciphers
     DevSec::Ssh::CRYPTO.each do |crypto_type, crypto_value| # we can not use subject here, as its not in the block
       function = "get_#{type}_#{crypto_type}"

--- a/spec/recipes/client_spec.rb
+++ b/spec/recipes/client_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 # Copyright 2016, Artem Sidorenko
@@ -181,7 +182,7 @@ describe 'ssh-hardening::client' do
   context 'with custom send_env attribute' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.normal['ssh-hardening']['ssh']['client']['send_env'] = %w(some environment variables)
+        node.normal['ssh-hardening']['ssh']['client']['send_env'] = %w[some environment variables]
       end.converge(described_recipe)
     end
 

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 # Copyright 2016, Artem Sidorenko
@@ -507,7 +508,7 @@ describe 'ssh-hardening::server' do
   context 'with attribute deny_users' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.normal['ssh-hardening']['ssh']['server']['deny_users'] = %w(someuser)
+        node.normal['ssh-hardening']['ssh']['server']['deny_users'] = %w[someuser]
       end.converge(described_recipe)
     end
 
@@ -520,7 +521,7 @@ describe 'ssh-hardening::server' do
   context 'with attribute deny_users mutiple' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.normal['ssh-hardening']['ssh']['server']['deny_users'] = %w(someuser otheruser)
+        node.normal['ssh-hardening']['ssh']['server']['deny_users'] = %w[someuser otheruser]
       end.converge(described_recipe)
     end
 
@@ -654,7 +655,7 @@ describe 'ssh-hardening::server' do
   context 'with custom accept_env attribute' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.normal['ssh-hardening']['ssh']['server']['accept_env'] = %w(some environment variables)
+        node.normal['ssh-hardening']['ssh']['server']['accept_env'] = %w[some environment variables]
       end.converge(described_recipe)
     end
 

--- a/spec/recipes/unlock_spec.rb
+++ b/spec/recipes/unlock_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/shared_examples_crypto.rb
+++ b/spec/shared_examples_crypto.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 # Copyright 2016, Artem Sidorenko
@@ -44,7 +45,7 @@ RSpec.shared_examples 'does not allow weak ciphers' do
 end
 
 RSpec.shared_examples 'allow ctr ciphers' do
-  let(:ctr_ciphers) { %w(aes256-ctr aes192-ctr aes128-ctr) }
+  let(:ctr_ciphers) { %w[aes256-ctr aes192-ctr aes128-ctr] }
   it 'should allow ctr ciphers' do
     ctr_ciphers.each do |cipher|
       expect(chef_run).to render_file(ssh_config_file).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #


### PR DESCRIPTION
Chef 13 is also using ruby 2.4.1 in the omnibus packages

There are problems with Chef 13.1 in the chefspec tests. The builds are getting stucked without any specific reason. I'll investigate this further...