### PR TITLE
Fix to Issue #180. Cookbook fails on Amazon Linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,7 +41,7 @@ end
 
 # Define the service name for sshd
 case node['platform_family']
-when 'rhel', 'fedora', 'suse', 'freebsd', 'gentoo'
+when 'rhel', 'fedora', 'suse', 'freebsd', 'gentoo', 'amazon'
   default['ssh-hardening']['sshserver']['service_name'] = 'sshd'
 else
   default['ssh-hardening']['sshserver']['service_name'] = 'ssh'


### PR DESCRIPTION
Since ohai v13.0.0, the attribute "platform_family" for Amazon Linux retrieves "amazon" instead of "rhel", causing the cookbook to fail. (Issue #180)

To get it fixed, it was added the value "amazon" to the case block on the default attribute file, where it is defined the service name for sshd.