### PR TITLE
Fix Extra Configuration

### DIFF
--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -203,6 +203,13 @@ UseDNS <%= ((@node['ssh-hardening']['ssh']['server']['use_dns']) ? 'yes' : 'no' 
 AcceptEnv <%= @node['ssh-hardening']['ssh']['server']['accept_env'].join(' ') %>
 <% end %>
 
+<%- unless @node['ssh-hardening']['ssh']['server']['extras'].empty? %>
+# Extra Configuration Options
+  <%- @node['ssh-hardening']['ssh']['server']['extras'].each do |key, value| %>
+<%= key %> <%= value %>
+  <% end -%>
+<% end -%>
+
 <% if @node['ssh-hardening']['ssh']['server']['sftp']['enable'] %>
 # Configuration, in case SFTP is used
 ## override default of no subsystems
@@ -234,10 +241,3 @@ X11Forwarding no
 #PermitRootLogin no
 #X11Forwarding no
 <% end %>
-
-<%- unless @node['ssh-hardening']['ssh']['server']['extras'].empty? %>
-# Extra Configuration Options
-  <%- @node['ssh-hardening']['ssh']['server']['extras'].each do |key, value| %>
-<%= key %> <%= value %>
-  <% end -%>
-<% end -%>


### PR DESCRIPTION
Extra config block needs to come before the potential SFTP Match configuration.  If SFTP is enabled, any extra configuration options fall under the match block and do not take effect.

The statement on this line is correct, Match blocks must always be at the end of the configuration file 😉  https://github.com/dev-sec/chef-ssh-hardening/blob/master/templates/default/opensshd.conf.erb#L227