### PR TITLE
Modified the client_alive_interval default to 300

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,7 +82,7 @@ default['ssh-hardening']['ssh']['server'].tap do |server| # rubocop: disable Blo
   server['dh_build_primes']          = false
   server['dh_build_primes_size']     = 4096
   server['host_key_files']           = nil
-  server['client_alive_interval']    = 600     # 10min
+  server['client_alive_interval']    = 300     # 5min
   server['client_alive_count']       = 3       # ~> 3 x interval
   server['allow_root_with_key']      = false
   server['allow_tcp_forwarding']     = false


### PR DESCRIPTION

While this cookbook isn't specific (and shouldn't be specific) to CIS Benchmarks, it's helpful as a
baseline to set the default behaviors to the recommended value. Folks can override to 600 if needed.
