### PR TITLE
Make PermitTunnel configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ override['ssh-hardening']['ssh']['server']['listen_to'] = node['ipaddress']
 * `['ssh-hardening']['ssh']['server']['allow_tcp_forwarding']` - `false`. Set to `true` to allow TCP Forwarding
 * `['ssh-hardening']['ssh']['server']['allow_agent_forwarding']` - `false`. Set to `true` to allow Agent Forwarding
 * `['ssh-hardening']['ssh']['server']['allow_x11_forwarding']` - `false`. Set to `true` to allow X11 Forwarding
+* `['ssh-hardening']['ssh']['server']['permit_tunnel']` - `false` to disable tun device forwarding. Set to `true` to allow tun device forwarding
 * `['ssh-hardening']['ssh']['server']['use_pam']` - `true`. Set to `false` to disable the pam authentication of sshd
 * `['ssh-hardening']['ssh']['server']['challenge_response_authentication']` - `false`. Set to `true` to enable challenge response authentication.
 * `['ssh-hardening']['ssh']['server']['deny_users']` - `[]` to configure `DenyUsers`, if specified login is disallowed for user names that match one of the patterns.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,6 +85,8 @@ default['ssh-hardening']['ssh']['server'].tap do |server| # rubocop: disable Blo
   server['client_alive_interval']    = 300     # 5min
   server['client_alive_count']       = 3       # ~> 3 x interval
   server['allow_root_with_key']      = false
+   
+  server['permit_tunnel']            = false
   server['allow_tcp_forwarding']     = false
   server['allow_agent_forwarding']   = false
   server['allow_x11_forwarding']     = false

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -157,7 +157,7 @@ ClientAliveInterval <%= @node['ssh-hardening']['ssh']['server']['client_alive_in
 ClientAliveCountMax <%= @node['ssh-hardening']['ssh']['server']['client_alive_count'] %>
 
 # Disable tunneling
-PermitTunnel <%= @node['ssh-hardening']['ssh']['server']['permit_tunnel'] %>
+PermitTunnel <%= ((@node['ssh-hardening']['ssh']['server']['permit_tunnel']) ? 'yes' : 'no' ) %>
 
 # Disable forwarding tcp connections.
 # no real advantage without denied shell access

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -157,7 +157,7 @@ ClientAliveInterval <%= @node['ssh-hardening']['ssh']['server']['client_alive_in
 ClientAliveCountMax <%= @node['ssh-hardening']['ssh']['server']['client_alive_count'] %>
 
 # Disable tunneling
-PermitTunnel no
+PermitTunnel <%= @node['ssh-hardening']['ssh']['server']['permit_tunnel'] %>
 
 # Disable forwarding tcp connections.
 # no real advantage without denied shell access


### PR DESCRIPTION
Sometimes you want to enable tunneling, the cookbook should at least allow such kind of configuration. All other "unsecure" options are also allowed to be changed...