### PR TITLE
Remove deprecated options

### DIFF
--- a/templates/default/openssh.conf.erb
+++ b/templates/default/openssh.conf.erb
@@ -82,10 +82,6 @@ ForwardX11 no
 
 # Never use host-based authentication. It can be exploited.
 HostbasedAuthentication no
-RhostsRSAAuthentication no
-
-# Enable RSA authentication via identity files.
-RSAAuthentication yes
 
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
 PasswordAuthentication <%= ((@node['ssh-hardening']['ssh']['client']['password_authentication']) ? "yes" : "no" ) %>
@@ -99,7 +95,6 @@ Tunnel no
 
 # Disable local command execution.
 PermitLocalCommand no
-
 
 # Misc. configuration
 # ===================


### PR DESCRIPTION
SSH protocol 1 server support removed
-------------------------------------

sshd(8) no longer supports the old SSH protocol 1, so all the configuration
options related to it are now deprecated and should be removed from
/etc/ssh/sshd_config.  These are:

  KeyRegenerationInterval
  RSAAuthentication
  RhostsRSAAuthentication
  ServerKeyBits

The Protocol option is also no longer needed, although it is silently
ignored rather than deprecated.

https://salsa.debian.org/ssh-team/openssh/commit/fb87db8aa47d3508be8e5bb1d21897fa1f2eca90