### PR TITLE
Avoid some deprecated options for OpenSSH >=7.6

### DIFF
--- a/libraries/devsec_ssh.rb
+++ b/libraries/devsec_ssh.rb
@@ -119,6 +119,13 @@ module DevSec
         get_crypto_data(:kexs, :server, enable_weak)
       end
 
+      { client: 'sshclient',
+        server: 'sshserver' }.each do |k, v|
+        define_method("get_ssh_#{k}_version") do
+          get_ssh_version(node['ssh-hardening'][v]['package'])
+        end
+      end
+
       private
 
       # :nocov:
@@ -168,13 +175,6 @@ module DevSec
         raise "Unsupported ssh version #{version}" unless found_ssh_version
 
         found_ssh_version
-      end
-
-      { client: 'sshclient',
-        server: 'sshserver' }.each do |k, v|
-        define_method("get_ssh_#{k}_version") do
-          get_ssh_version(node['ssh-hardening'][v]['package'])
-        end
       end
 
       def get_ssh_version(package)

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -48,7 +48,8 @@ template '/etc/ssh/ssh_config' do
       {
         mac:     node['ssh-hardening']['ssh']['client']['mac']    || DevSec::Ssh.get_client_macs(node['ssh-hardening']['ssh']['client']['weak_hmac']),
         kex:     node['ssh-hardening']['ssh']['client']['kex']    || DevSec::Ssh.get_client_kexs(node['ssh-hardening']['ssh']['client']['weak_kex']),
-        cipher:  node['ssh-hardening']['ssh']['client']['cipher'] || DevSec::Ssh.get_client_ciphers(node['ssh-hardening']['ssh']['client']['cbc_required'])
+        cipher:  node['ssh-hardening']['ssh']['client']['cipher'] || DevSec::Ssh.get_client_ciphers(node['ssh-hardening']['ssh']['client']['cbc_required']),
+        version: DevSec::Ssh.get_ssh_client_version
       }
     end
   )

--- a/spec/libraries/devsec_ssh_spec.rb
+++ b/spec/libraries/devsec_ssh_spec.rb
@@ -195,20 +195,6 @@ describe DevSec::Ssh do
     end
   end
 
-  describe 'get_ssh_server_version' do
-    it 'should call get_ssh_version with server package attribute' do
-      expect(subject).to receive(:get_ssh_version).with(package_name)
-      subject.send(:get_ssh_server_version)
-    end
-  end
-
-  describe 'get_ssh_client_version' do
-    it 'should call get_ssh_version with client package attribute' do
-      expect(subject).to receive(:get_ssh_version).with(package_name)
-      subject.send(:get_ssh_client_version)
-    end
-  end
-
   describe 'find_ssh_version' do
     context 'when it gets the valid ssh version' do
       it 'should return the next small version' do
@@ -312,6 +298,20 @@ describe DevSec::Ssh do
           end
         end
       end
+    end
+  end
+
+  describe 'get_ssh_server_version' do
+    it 'should call get_ssh_version with server package attribute' do
+      expect(subject).to receive(:get_ssh_version).with(package_name)
+      subject.send(:get_ssh_server_version)
+    end
+  end
+
+  describe 'get_ssh_client_version' do
+    it 'should call get_ssh_version with client package attribute' do
+      expect(subject).to receive(:get_ssh_version).with(package_name)
+      subject.send(:get_ssh_client_version)
     end
   end
 end

--- a/spec/recipes/client_spec.rb
+++ b/spec/recipes/client_spec.rb
@@ -219,6 +219,26 @@ describe 'ssh-hardening::client' do
     end
   end
 
+  describe 'version specifc options' do
+    context 'running with OpenSSH < 7.6' do
+      it 'should have RhostsRSAAuthentication and RSAAuthentication' do
+        expect(chef_run).to render_file('/etc/ssh/ssh_config').with_content(/RhostsRSAAuthentication/)
+        expect(chef_run).to render_file('/etc/ssh/ssh_config').with_content(/RSAAuthentication/)
+      end
+    end
+
+    context 'running with OpenSSH >= 7.6 on Ubuntu 18.04' do
+      cached(:chef_run) do
+        ChefSpec::ServerRunner.new(version: '18.04').converge(described_recipe)
+      end
+
+      it 'should not have RhostsRSAAuthentication and RSAAuthentication' do
+        expect(chef_run).to_not render_file('/etc/ssh/ssh_config').with_content(/RhostsRSAAuthentication/)
+        expect(chef_run).to_not render_file('/etc/ssh/ssh_config').with_content(/RSAAuthentication/)
+      end
+    end
+  end
+
   context 'chef-solo' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new.converge(described_recipe)

--- a/templates/default/openssh.conf.erb
+++ b/templates/default/openssh.conf.erb
@@ -82,10 +82,13 @@ ForwardX11 no
 
 # Never use host-based authentication. It can be exploited.
 HostbasedAuthentication no
+
+<% if @version.to_f < 7.6 %>
 RhostsRSAAuthentication no
 
 # Enable RSA authentication via identity files.
 RSAAuthentication yes
+<% end %>
 
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
 PasswordAuthentication <%= ((@node['ssh-hardening']['ssh']['client']['password_authentication']) ? "yes" : "no" ) %>


### PR DESCRIPTION
E.g. on Ubuntu 18.04

Fixes #195 