### PR TITLE
Update of badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # ssh-hardening (Chef cookbook)
 
 [![Supermarket](http://img.shields.io/cookbook/v/ssh-hardening.svg)][1]
-[![Build Status](http://img.shields.io/travis/dev-sec/chef-ssh-hardening.svg)][2]
+[![Build Status](https://travis-ci.org/dev-sec/chef-ssh-hardening.svg?branch=master)][2]
 [![Code Coverage](http://img.shields.io/coveralls/dev-sec/chef-ssh-hardening.svg)][3]
-[![Dependencies](http://img.shields.io/gemnasium/dev-sec/chef-ssh-hardening.svg)][4]
-[![Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)][5]
+[![Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)][4]
 
 ## Description
 
@@ -252,5 +251,4 @@ limitations under the License.
 [1]: https://supermarket.getchef.com/cookbooks/ssh-hardening
 [2]: http://travis-ci.org/dev-sec/chef-ssh-hardening
 [3]: https://coveralls.io/r/dev-sec/chef-ssh-hardening
-[4]: https://gemnasium.com/dev-sec/chef-ssh-hardening
-[5]: https://gitter.im/dev-sec/general
+[4]: https://gitter.im/dev-sec/general


### PR DESCRIPTION
- Removal of gemnaisum badge
- Use the CI badge from master branch only but not from the any last build

Signed-off-by: Artem Sidorenko <artem@posteo.de>