### PR TITLE
Allow to specify an alternate AuthorizedKeysFile inside the Match block

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ override['ssh-hardening']['ssh']['server']['listen_to'] = node['ipaddress']
 * `['ssh-hardening']['ssh']['server']['sftp']['enable']` - `false`. Set to `true` to enable the SFTP feature of OpenSSH daemon
 * `['ssh-hardening']['ssh']['server']['sftp']['group']` - `sftponly`. Sets the `Match Group` option of SFTP to allow SFTP only for dedicated users
 * `['ssh-hardening']['ssh']['server']['sftp']['chroot']` - `/home/%u`. Sets the directory where the SFTP user should be chrooted
+* `['ssh-hardening']['ssh']['server']['sftp']['authorized_keys_path']` - `nil`. If not nil, full path to one or multipe space-separated authorized keys file that will be set inside the `Match Group` for SFTP-only access
 * `['ssh-hardening']['ssh']['server']['sftp']['password_authentication']` - `false`. Set to `true` if password authentication should be enabled
-* `['ssh-hardening']['ssh']['server']['authorized_keys_path']` - `nil`. If not nil, full path to an authorized keys folder is expected
+* `['ssh-hardening']['ssh']['server']['authorized_keys_path']` - `nil`. If not nil, full path to one or multipe space-separated authorized keys file is expected.
 * `['ssh-hardening']['ssh']['server']['extras']` - `{}`. Add extra configuration options, see [below](#extra-configuration-options) for details
 * `['ssh-hardening']['ssh']['server']['match_blocks']` - `{}`. Match configuration block, see [below](#match-configuration-options-for-sshd) for details
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -108,7 +108,7 @@ default['ssh-hardening']['ssh']['server'].tap do |server| # rubocop: disable Blo
   server['password_authentication']  = false
   server['log_level']                = 'verbose'
   server['accept_env']               = ['LANG', 'LC_*', 'LANGUAGE']
-  server['authorized_keys_path']     = nil     # if not nil, full path to an authorized keys folder is expected
+  server['authorized_keys_path']     = nil     # if not nil, full path to one or multipe space-separated authorized keys file is expected
 
   # extra server configuration options
   server['extras']                   = {}
@@ -121,5 +121,6 @@ default['ssh-hardening']['ssh']['server'].tap do |server| # rubocop: disable Blo
   server['sftp']['log_level']               = 'VERBOSE'
   server['sftp']['group']                   = 'sftponly'
   server['sftp']['chroot']                  = '/home/%u'
+  server['sftp']['authorized_keys_path']    = nil     # if not nil, full path to one or multipe space-separated authorized keys file is expected
   server['sftp']['password_authentication'] = false
 end

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -707,7 +707,7 @@ describe 'ssh-hardening::server' do
 
     it 'sets the SFTP chroot correctly' do
       expect(chef_run).to render_file('/etc/ssh/sshd_config').
-        with_content(/^ChrootDirectory test_home_dir$/)
+        with_content(/^[[:space:]]*ChrootDirectory test_home_dir$/)
     end
   end
 
@@ -772,14 +772,28 @@ describe 'ssh-hardening::server' do
 
       it 'does not have AuthorizedKeysFile configured' do
         expect(chef_run).not_to render_file('/etc/ssh/sshd_config').
-          with_content('AuthorizedKeysFile')
+          with_content(/^[[:space:]]*AuthorizedKeysFile/)
       end
     end
 
-    context 'with customized AuthorizedKeysFile' do
+    context 'with customized global AuthorizedKeysFile' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
           node.normal['ssh-hardening']['ssh']['server']['authorized_keys_path'] = '/some/authorizedkeysfile'
+        end.converge(described_recipe)
+      end
+
+      it 'has AuthorizedKeysFile configured' do
+        expect(chef_run).to render_file('/etc/ssh/sshd_config').
+          with_content('AuthorizedKeysFile /some/authorizedkeysfile')
+      end
+    end
+
+    context 'with customized sftponly AuthorizedKeysFile' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new do |node|
+          node.normal['ssh-hardening']['ssh']['server']['sftp']['enable'] = true
+          node.normal['ssh-hardening']['ssh']['server']['sftp']['authorized_keys_path'] = '/some/authorizedkeysfile'
         end.converge(described_recipe)
       end
 

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -222,13 +222,16 @@ Subsystem sftp internal-sftp -l <%= @node['ssh-hardening']['ssh']['server']['sft
 
 ## These lines must appear at the *end* of sshd_config
 Match Group <%= @node['ssh-hardening']['ssh']['server']['sftp']['group'] %>
-ForceCommand internal-sftp -l <%= @node['ssh-hardening']['ssh']['server']['sftp']['log_level'] %>
-ChrootDirectory <%= @node['ssh-hardening']['ssh']['server']['sftp']['chroot'] %>
-AllowTcpForwarding no
-AllowAgentForwarding no
-PasswordAuthentication <%= ((@node['ssh-hardening']['ssh']['server']['sftp']['password_authentication']) ? 'yes' : 'no' ) %>
-PermitRootLogin no
-X11Forwarding no
+  ForceCommand internal-sftp -l <%= @node['ssh-hardening']['ssh']['server']['sftp']['log_level'] %>
+  ChrootDirectory <%= @node['ssh-hardening']['ssh']['server']['sftp']['chroot'] %>
+<% if @node['ssh-hardening']['ssh']['server']['sftp']['authorized_keys_path'] %>
+  AuthorizedKeysFile <%= @node['ssh-hardening']['ssh']['server']['sftp']['authorized_keys_path'] %>
+<% end %>
+  AllowTcpForwarding no
+  AllowAgentForwarding no
+  PasswordAuthentication <%= ((@node['ssh-hardening']['ssh']['server']['sftp']['password_authentication']) ? 'yes' : 'no' ) %>
+  PermitRootLogin no
+  X11Forwarding no
 <% else %>
 # Configuration, in case SFTP is used
 ## override default of no subsystems
@@ -237,13 +240,14 @@ X11Forwarding no
 #
 ## These lines must appear at the *end* of sshd_config
 #Match Group sftponly
-#ForceCommand internal-sftp -l VERBOSE
-#ChrootDirectory /sftpchroot/home/%u
-#AllowTcpForwarding no
-#AllowAgentForwarding no
-#PasswordAuthentication no
-#PermitRootLogin no
-#X11Forwarding no
+  #ForceCommand internal-sftp -l VERBOSE
+  #ChrootDirectory /sftpchroot/home/%u
+  #AuthorizedKeysFile /sftpchroot/home/%u/.ssh/authorized_keys
+  #AllowTcpForwarding no
+  #AllowAgentForwarding no
+  #PasswordAuthentication no
+  #PermitRootLogin no
+  #X11Forwarding no
 <% end %>
 
 <%- unless @node['ssh-hardening']['ssh']['server']['match_blocks'].empty? %>


### PR DESCRIPTION
Since OpenSSH OpenSSH 5.6 (2010-08-23), one can specify an AuthorizedKeysFile parameter inside the Match block.

I didn't add any test because I don't think rspec can handle multiple parameters (the global one & the Match one).