### PR TITLE
Support of custom match configuration blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   Exclude:
   - vendor/**/*
   - test/**/*
-  TargetRubyVersion: 2.1 # we need this because of chef 12.5.1 support
+  TargetRubyVersion: 2.4
 Metrics/AbcSize:
   Max: 29
 Metrics/CyclomaticComplexity:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ override['ssh-hardening']['ssh']['server']['listen_to'] = node['ipaddress']
 * `['ssh-hardening']['ssh']['server']['sftp']['password_authentication']` - `false`. Set to `true` if password authentication should be enabled
 * `['ssh-hardening']['ssh']['server']['authorized_keys_path']` - `nil`. If not nil, full path to an authorized keys folder is expected
 * `['ssh-hardening']['ssh']['server']['extras']` - `{}`. Add extra configuration options, see [below](#extra-configuration-options) for details
+* `['ssh-hardening']['ssh']['server']['match_blocks']` - `{}`. Match configuration block, see [below](#match-configuration-options-for-sshd) for details
 
 ## Usage
 
@@ -142,6 +143,24 @@ end
 default['ssh-hardening']['ssh']['client']['extras'].tap do |extra|
   extra['PermitLocalCommand'] = 'no'
   extra['Tunnel'] =  'no'
+end
+```
+
+## Match Configuration Options for sshd
+Match blocks have to be placed by the end of sshd_config. This can be achieved by using the `match_blocks` attribute tree:
+
+```
+default['ssh-hardening']['ssh']['server']['match_blocks'].tap do |match|
+  match['User root'] = <<~ROOT
+    AuthorizedKeysFile .ssh/authorized_keys
+  ROOT
+  match['User git'] = <<~GIT
+    Banner none
+    AuthorizedKeysCommand /bin/false
+    AuthorizedKeysFile .ssh/authorized_keys
+    GSSAPIAuthentication no
+    PasswordAuthentication no
+  GIT
 end
 ```
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,6 +113,9 @@ default['ssh-hardening']['ssh']['server'].tap do |server| # rubocop: disable Blo
   # extra server configuration options
   server['extras']                   = {}
 
+  # server match configuration block
+  server['match_blocks']             = {}
+
   # sshd sftp options
   server['sftp']['enable']                  = false
   server['sftp']['log_level']               = 'VERBOSE'

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -245,3 +245,11 @@ X11Forwarding no
 #PermitRootLogin no
 #X11Forwarding no
 <% end %>
+
+<%- unless @node['ssh-hardening']['ssh']['server']['match_blocks'].empty? %>
+# Match Configuration Blocks
+  <%- @node['ssh-hardening']['ssh']['server']['match_blocks'].each do |key, value| %>
+Match <%= key %>
+  <%= value.split("\n").join("\n  ") %>
+  <% end -%>
+<% end -%>


### PR DESCRIPTION
They are sometimes useful when you need to have user/group rectrictions or want to override some global configuration options

Signed-off-by: Artem Sidorenko <artem.sidorenko@t-systems.com>