### PR TITLE
add centos 8 alt platforms - rocky, almalinux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@
 
 # Define the client package name
 case node['platform']
-when 'redhat', 'centos', 'fedora', 'amazon', 'oracle', 'scientific'
+when 'redhat', 'centos', 'fedora', 'amazon', 'oracle', 'scientific', 'rocky', 'almalinux'
   default['ssh-hardening']['sshclient']['package'] = 'openssh-clients'
 when 'debian', 'ubuntu'
   default['ssh-hardening']['sshclient']['package'] = 'openssh-client'


### PR DESCRIPTION
Simple change to add support for CentOS 8 alternatives Rocky Linux and Almalinux

Ref: https://docs.chef.io/infra_language/checking_platforms/